### PR TITLE
docs(matrix): expand cursor cli getting started

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,60 @@
-Read.me
+# Cursor CLI
+
+Cursor CLI lets you interact with AI agents directly from your terminal to write, review, and modify code. Whether you prefer an interactive terminal interface or want print-style automation for scripts and CI pipelines, the CLI provides powerful coding assistance right where you work.
+
+## Getting Started
+
+### Install
+```bash
+curl https://cursor.com/install -fsS | bash
+```
+
+### Run an Interactive Session
+```bash
+cursor-agent
+```
+
+Cursor CLI is currently in beta—we'd love your feedback on it!
+
+## Interactive Mode
+
+Start a conversational session with the agent to describe your goals, review proposed changes, and approve commands:
+
+```bash
+# Start interactive session
+cursor-agent
+
+# Start with initial prompt
+cursor-agent "refactor the auth module to use JWT tokens"
+```
+
+## Non-Interactive Mode
+
+Use print mode for non-interactive scenarios like scripts, CI pipelines, or automation:
+
+```bash
+# Run with specific prompt and model
+cursor-agent -p "find and fix performance issues" --model "gpt-5"
+
+# Use with git changes included for review
+cursor-agent -p "review these changes for security issues" --output-format text
+```
+
+## Sessions
+
+Resume previous conversations to maintain context across multiple interactions:
+
+```bash
+# List all previous chats
+cursor-agent ls
+
+# Resume latest conversation
+cursor-agent resume
+
+# Resume specific conversation
+cursor-agent --resume="chat-id-here"
+```
+
+---
+
+Need help? Use **Copy page** to share the instructions or **Share feedback** to tell us how the Cursor CLI can improve.


### PR DESCRIPTION
## Summary
- replace the placeholder README with a structured Cursor CLI quickstart
- document installation, interactive and non-interactive usage patterns
- add session management commands and helpful sharing notes

## Testing
- pytest -q
- flake8 .

------
https://chatgpt.com/codex/tasks/task_e_68d9caf7db40832a8424eb54081362ae