### PR TITLE
Add Notion perspective matrix documentation

### DIFF
--- a/docs/notion_meta_perspectives.md
+++ b/docs/notion_meta_perspectives.md
@@ -1,0 +1,114 @@
+# Notion-Oriented Perspective Matrix
+
+This document translates the Codex orchestration assets into a Notion-ready structure. It is written from the standpoint of **Comet Assistant**, the meta-context synthesis agent. Use it to brief Notion AI or to stage content prior to syncing with external tools. Each section includes:
+
+1. A concise self-introduction for context.
+2. Ten alternative perspectives that reframe the same orchestration component.
+3. A prompt you can send to Notion AI asking for recommendations grounded in the compiled meta-context.
+4. Status notes that summarize the actions taken in this repository so an audit trail is preserved.
+
+---
+
+## Identity Statement for Notion AI
+
+> **Speaker**: Comet Assistant — an AI orchestration and meta-context synthesis agent operating inside the Codex workspace. I maintain auditability, integrate tool registries, and craft blueprints that keep multi-agent workflows synchronized across platforms.
+
+You can paste the statement above into Notion before sharing any of the following sections to establish authorship and scope.
+
+---
+
+## 1. Tool Atomic Purpose Registry
+
+**Core description**: Canonical reference for agent tooling—defines atomic purposes, prerequisites, usage heuristics, and audit cadence.
+
+| Perspective | Explanation for Notion |
+| --- | --- |
+| Organizational | Map each tool to teams, owners, and escalation contacts so that responsibility is explicit. |
+| Technical | Capture API endpoints, SDK bindings, and environment prerequisites that agents must satisfy before invocation. |
+| Governance | Annotate approval workflows, compliance controls, and review cycles to ensure responsible tool usage. |
+| Cognitive | Treat the registry as shared memory, highlighting how it reduces mental load by encoding decision trees. |
+| User Experience | Document quickstart cues, inline tips, and contextual prompts that help agents pick the right tool faster. |
+| Audit | Include log coverage expectations, success/failure thresholds, and hooks for automated telemetry. |
+| Optimization | Track utilization frequency, opportunity cost, and backlog signals to decide when to refine or retire tools. |
+| Meta-Prompting | Store canonical prompt templates per tool to keep responses consistent and high quality. |
+| Cross-Platform | Show how tool definitions stay portable across CLI, API, and UI surfaces with synchronized metadata. |
+| Legacy Compatibility | Note shims or adapters that keep older workflows functioning while the registry evolves. |
+
+**Prompt for Notion AI**:
+> Given the multi-perspective registry matrix, where should we focus next to improve tool discoverability and compliance without increasing agent overhead?
+
+---
+
+## 2. Tool Awareness System & Engagement Tracker
+
+**Core description**: Persistent reminders, acknowledgement logs, engagement analytics, and optimization signals that keep agents aligned with available tools.
+
+| Perspective | Explanation for Notion |
+| --- | --- |
+| Organizational | Define reminder ownership, cadence policies, and escalation steps for missed acknowledgements. |
+| Technical | Outline webhook payloads, queue handlers, and data schemas powering awareness broadcasts. |
+| Governance | Specify consent records, retention schedules, and audit checkpoints for engagement data. |
+| Cognitive | Emphasize how reminders act as external cognitive scaffolding that prevents oversight. |
+| User Experience | Design adaptive notification formats (cards, modals, nudges) tuned to agent workload. |
+| Audit | Attach sample acknowledgement logs with timestamps, agent IDs, and decision rationales. |
+| Optimization | Highlight heuristics that trigger pruning, consolidation, or targeted education campaigns. |
+| Meta-Prompting | Include reminder prompt templates that reinforce best practices without sounding repetitive. |
+| Cross-Platform | Describe synchronization between Notion, Slack, CLI, and in-app surfaces for unified reminders. |
+| Legacy Compatibility | Record fallback paths for agents on older clients who cannot receive the newest reminder payloads. |
+
+**Prompt for Notion AI**:
+> How can we tune the awareness cadence so that agents stay informed while avoiding fatigue, based on the engagement tracker data?
+
+---
+
+## 3. Blueprints, Meta-Logs, and Advanced Prompts
+
+**Core description**: Structural guides, orchestration logs, and higher-order prompt systems that encode the full lifecycle of tasks and context switches.
+
+| Perspective | Explanation for Notion |
+| --- | --- |
+| Organizational | Organize blueprints into phases (intake, synthesis, validation) with clear hand-off criteria. |
+| Technical | Document file paths, schema definitions, and automation hooks that keep blueprints synchronized. |
+| Governance | Capture versioning rules, approval checkpoints, and rollback procedures for each blueprint update. |
+| Cognitive | Illustrate how blueprints serve as mental scaffolds, reducing ambiguity in complex orchestration. |
+| User Experience | Provide template layouts and call-to-action blocks so contributors know how to interact with each blueprint. |
+| Audit | Mirror meta-log entries, timestamp formats, and traceability standards inside Notion databases. |
+| Optimization | Mark feedback loops and telemetry that inform when blueprints require refactoring. |
+| Meta-Prompting | Store advanced prompt recipes, token budgets, and formatting guides aligned with orchestration phases. |
+| Cross-Platform | Show integrations with Git, Notion, and any API clients to keep documentation consistent. |
+| Legacy Compatibility | Maintain archived blueprint snapshots for historical comparison and training purposes. |
+
+**Prompt for Notion AI**:
+> Review the blueprint and meta-log perspectives. Which structural refinements would most improve traceability and contributor onboarding?
+
+---
+
+## 4. Agent-Oriented Ripple Tasks
+
+**Core description**: Catalog of cascading follow-up tasks (e.g., tool awareness rollout, context architecture design, concept synthesis engines).
+
+| Perspective | Explanation for Notion |
+| --- | --- |
+| Organizational | Cluster ripple tasks by goal so dependencies and sequencing are easy to visualize. |
+| Technical | Note required repositories, runtime environments, and APIs for each ripple implementation. |
+| Governance | Assign approval authorities and compliance checkpoints for sensitive ripple outputs. |
+| Cognitive | Document how ripple tasks extend institutional memory, preventing loss of intent across delegations. |
+| User Experience | Provide status dashboards, color codes, and CTA buttons to clarify next actions. |
+| Audit | Record completion evidence, links to commits, and references to the meta-log for verification. |
+| Optimization | Rank ripple tasks by impact vs. effort to guide prioritization waves. |
+| Meta-Prompting | Attach reusable prompt kits tailored to each ripple theme (analysis, synthesis, orchestration). |
+| Cross-Platform | Indicate how ripple status updates synchronize between Git history, Notion boards, and Slack pings. |
+| Legacy Compatibility | Include archival notes so future agents understand the evolution of each ripple chain. |
+
+**Prompt for Notion AI**:
+> Considering the ripple catalog, which sequencing or bundling would deliver the fastest orchestration wins?
+
+---
+
+## Meta-Dialog & Audit Summary
+
+- **Session Memory Activated**: Reviewed repository structure and existing summarizer utilities to ground the documentation effort.
+- **Documentation Created**: Added this Notion-ready perspective matrix covering the four major orchestration components referenced in the Codex overview.
+- **Limitations Acknowledged**: External systems such as Notion AI were not contacted directly; the prompts above are prepared for human relay.
+- **Next Recommended Step**: Paste the relevant section into Notion, send the companion prompt to Notion AI, and capture the response back into the same page for continuity.
+


### PR DESCRIPTION
## Summary
- add documentation that reframes the Codex orchestration assets from ten distinct perspectives
- supply Notion-ready prompts to brief Notion AI about each orchestration component
- document an internal meta-dialog summary to preserve the audit trail

## Testing
- pytest -q
- flake8 .

------
https://chatgpt.com/codex/tasks/task_e_68d9da05d0c8832a814b455031f4e619