### PR TITLE
Create meta-orchestration task catalog

### DIFF
--- a/docs/task_catalog.md
+++ b/docs/task_catalog.md
@@ -1,0 +1,57 @@
+# Meta-Orchestration Task Catalog
+
+This catalog organizes the initiatives mentioned in the latest planning prompt into thematic groups. Each entry captures the intent, likely deliverables, and open coordination questions so that subsequent orchestration passes can build from a shared baseline.
+
+## Orchestration Infrastructure
+
+| Initiative | Focus | Expected Outputs | Open Questions |
+| --- | --- | --- | --- |
+| Implement agent tool awareness system | Instrument agents so they understand available tools, capabilities, and invocation constraints. | Capability registry, self-check routines, tool-use telemetry. | What standards define "awareness"? How to keep the registry up to date? |
+| Design auditable context management system | Ensure state transitions between agents are transparent and reviewable. | Context ledger, trace IDs, review interface. | Which privacy constraints apply to stored context? |
+| Create meta-organization tracker and reminders | Provide top-level view of projects, owners, and due dates. | Tracker schema, notification cadence, dashboard mockups. | Which communication channels should reminders target? |
+| Design architectural blueprint for context organization | Establish blueprint for storing and linking prompts, memories, and artifacts. | Architecture diagrams, data flow narratives, storage policies. | How to balance retrieval speed with compliance requirements? |
+| Create Orchestration Status Tracking System | Monitor progress of orchestration modules and surface blockers early. | Status board, heartbeat metrics, escalation playbook. | How often should status snapshots be recorded? |
+| Initialize Phase 3 Modules with Integration Logic | Connect upcoming modules with shared services (context store, telemetry, auth). | Integration plan, interface contracts, smoke-test scenarios. | Which dependencies must be ready before Phase 3 starts? |
+| Create batch modules 4-8 for orchestration system | Implement mid-phase modules in a coordinated release. | Module specs, implementation roadmap, validation checklist. | What sequencing dependencies exist among modules 4-8? |
+| Initialize final 8 modules for orchestration - Donaldjohns0n/Pages | Stand up final module wave within the Pages workspace. | Deployment scripts, workspace linking notes, acceptance criteria. | Are there workspace-specific constraints for Donaldjohns0n/Pages? |
+| Create meta-prompt orchestration system | Build framework for storing, versioning, and deploying meta-prompts. | Meta-prompt repository, versioning rules, deployment pipeline. | How will conflicting prompt versions be resolved? |
+| Create advanced meta-prompt orchestration system | Extend baseline system with adaptive routing, analytics, and safeguards. | Adaptive prompt router, analytics dashboards, guardrail policies. | What metrics define success for the advanced layer? |
+| Create meta-analysis system for AI agents | Aggregate outputs from multiple agents to deliver synthesized findings. | Aggregation pipeline, weighting heuristics, report templates. | How should confidence scores be calibrated across agents? |
+
+## Knowledge Extraction & Synthesis
+
+| Initiative | Focus | Expected Outputs | Open Questions |
+| --- | --- | --- | --- |
+| Summarize New Research Findings for Lay Audience | Translate complex research bullet points into accessible narrative summaries. | Style guide, summary templates, feedback rubric. | Which audience personas should guide tone and depth? |
+| Analyze Codex advantages in orchestration | Evaluate how Codex supports multi-agent coordination tasks. | Comparative analysis, capability matrix, integration notes. | What benchmarks should be used to measure orchestration value? |
+| Implement Concept Synthesis Engine Logic | Combine disparate knowledge artifacts into coherent themes. | Synthesis algorithms, validation datasets, evaluation metrics. | How will conflicting concepts be reconciled? |
+| Implement Cross-Source Dependency Mapper | Trace dependencies among knowledge artifacts across repositories. | Dependency schema, visualization tool, sync process. | Which sources have authoritative precedence when conflicts arise? |
+| Initialize Atomic Knowledge Extractor Module | Extract minimal, verifiable facts from inputs for reuse across workflows. | Extraction pipeline, fact schema, provenance logging. | How to handle ambiguous or low-confidence extractions? |
+| Implement agent tool awareness system (research variant) | Extend tool awareness into research workflows to map evidence to tools. | Tool-to-evidence matrix, workflow playbooks. | Should awareness extend to external data providers? |
+
+## Repository & Integration Workstreams
+
+| Initiative | Focus | Expected Outputs | Open Questions |
+| --- | --- | --- | --- |
+| Add Codex Integration Task in Donaldjohns0n/personal Repository | Embed Codex capabilities into the personal repository's automation stack. | Integration branch plan, API configuration, CI validation. | What access scopes are needed for Codex within the repo? |
+| GitHub Pull Request #1 on Donaldjohns0n/GIt Repository | Track status and required follow-ups for the first PR. | Review checklist, outstanding comments, merge readiness notes. | Are additional reviewers required before merging? |
+| Initialize final 8 modules for orchestration - Donaldjohns0n/Pages | (Linked to orchestration wave) coordinate with repository workstreams. | See orchestration deliverables. | What repository hooks must be updated post-initialization? |
+
+## Meta-Coordination Prompts & Assistants
+
+| Initiative | Focus | Expected Outputs | Open Questions |
+| --- | --- | --- | --- |
+| Codex (meta entry) | Central assistant providing repository-aware execution and PR support. | Capability overview, usage guidelines, escalation pathways. | Which governance model defines Codex's role across teams? |
+| Create Accountant AI Research Orchestrator | Develop specialized orchestrator for finance/accounting research domains. | Domain ontologies, compliance guardrails, workflow automations. | What regulatory frameworks must be encoded (e.g., GAAP, IFRS)? |
+| Implement agent tool awareness system (accounting variant) | Adapt tool awareness to accountant research orchestrator. | Tool catalog, audit compatibility mapping, training guides. | How to ensure segregation of duties within tool assignments? |
+
+## Open Follow-Ups
+
+1. Validate whether "ripple pages" introduce additional task lists beyond the items captured above.
+2. Capture metadata (owners, due dates, dependencies) once stakeholders provide authoritative sources.
+3. Confirm protocols for interacting with Notion, Google Drive, and other external systems within current execution constraints.
+4. Establish audit logging format that satisfies the Meta-Orchestration Protocol.
+
+---
+
+*This catalog serves as a staging surface for future orchestration passes. Update entries as new prompts or ripple documents become available.*


### PR DESCRIPTION
## Summary
- add a task catalog that organizes the orchestration initiatives from the latest planning prompt
- group initiatives into infrastructure, knowledge, repository, and meta-coordination themes with open questions
- capture follow-up actions for ripple pages and external coordination protocols

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d9da3860a8832ab17c5184425f257b